### PR TITLE
Switch model generation to new monorepo structure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,10 @@ pipeline {
                 build job: '/FINTLabs/fint-devops-model-release/master', parameters: [
                     string(name: 'MODEL_VERSION', value: "${VERSION}"),
                     string(name: 'VERSION', value: "${VERSION}")]
+                build job: '/FINTLabs/job/fint-graphql/master', parameters: [
+                    string(name: 'MODEL_VERSION', value: "${VERSION}")]
+                build job: '/FINTLabs/job/fint-jsonschema/master', parameters: [
+                    string(name: 'MODEL_VERSION', value: "${VERSION}")]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,6 @@ pipeline {
                 build job: '/FINTLabs/fint-devops-model-release/master', parameters: [
                     string(name: 'MODEL_VERSION', value: "${VERSION}"),
                     string(name: 'VERSION', value: "${VERSION}")]
-                build job: '/FINTLabs/fint-devops-model-release/resource', parameters: [
-                    string(name: 'MODEL_VERSION', value: "${VERSION}"),
-                    string(name: 'VERSION', value: "${VERSION}")]
             }
         }
     }


### PR DESCRIPTION
Use FINTLabs/fint-devops-model-release#2 to generate models in new monorepositories for Java and C# models.

Also triggers generation of GraphQL and JSON schema for the same version.